### PR TITLE
pretty printing - fixed spacing after closing paren

### DIFF
--- a/Language/LBNF/Runtime.hs
+++ b/Language/LBNF/Runtime.hs
@@ -90,8 +90,8 @@ render d = rend 0 (map ($ "") $ d []) "" where
     "}"      :ts -> new (i-1) . showChar '}' . new (i-1) . rend (i-1) ts
     ";"      :ts -> showChar ';' . new i . rend i ts
     t  : "," :ts -> showString t . space "," . rend i ts
-    t  : ")" :ts -> showString t . showChar ')' . rend i ts
-    t  : "]" :ts -> showString t . showChar ']' . rend i ts
+    t  : ")" :ts -> showString t . rend i (")":ts)
+    t  : "]" :ts -> showString t . rend i ("]":ts)
     t        :ts -> space t . rend i ts
     _            -> id
   new i   = showChar '\n' . replicateS (2*i) (showChar ' ') . dropWhile isSpace


### PR DESCRIPTION
The pretty printer omitted space after a single closing paren/square paren.

This pull fixes it, keeping behavior of multiple closing parens.
